### PR TITLE
Update readme.md

### DIFF
--- a/tutorial-1/readme.md
+++ b/tutorial-1/readme.md
@@ -1,31 +1,31 @@
-# Log shipping into ElasticSearch
+# Log Shipping into Elasticsearch
 
-In this two part tutorial, we will learn how to read apache web server logs and send them to ElasticSearch. Along the way we will transform the data and set up alerts and data rules to let us know if any bad data is encountered. And finally we'll learn how to adapt the pipeline when data suddenly changes.
+In this two part tutorial, we will learn how to read Apache web server logs and send them to Elasticsearch. Along the way we will transform the data and set up alerts and data rules to let us know if any bad data is encountered. And finally, we'll learn how to adapt the pipeline when data suddenly changes.
 
-The Data Collector can read from and write to a large number of sources and destinations, but for this tutorial we will limit our scope to a File Directory Source and an ElasticSearch Destination.
+Data Collector can read from and write to a large number of origins and destinations, but for this tutorial we will limit our scope to a Directory origin and Elasticsearch destination.
 
-[![Log shipping into Elastic](img/vimeo-thumbnail.png)](https://vimeo.com/152097120 "Log shipping into Elastic")
+[![Log shipping into Elasticsearch](img/vimeo-thumbnail.png)](https://vimeo.com/152097120 "Log shipping into Elasticsearch")
 
 ## Goals
-The goal of this tutorial is to gather apache log files and send them to ElasticSearch.
+The goal of this tutorial is to gather Apache log files and send them to Elasticsearch.
 
 ## Pre-requisites
-* A working instance of StreamSets Data Collector
-* Access to ElasticSearch and Kibana
-* A copy of this tutorials directory containing the [sample data](../sample_data) and [pipeline](pipelines/Directory_to_ElasticSearch_Tutorial_Part_1.json)
-* A copy of the MaxMind GeoLite2 free IP Geolocation Database. *Either get and unzip the binary file or use the csv file* [GeoLite2 City](https://dev.maxmind.com/geoip/geoip2/geolite2/).
+* A working instance of StreamSets Data Collector.
+* Access to Elasticsearch and Kibana.
+* A copy of this tutorials directory containing the [sample data](../sample_data) and [pipeline](pipelines/Directory_to_Elasticsearch_Tutorial_Part_1.json).
+* A copy of the MaxMind GeoLite2 free IP geolocation database. *Either get and unzip the binary file or use the csv file* [GeoLite2 City](https://dev.maxmind.com/geoip/geoip2/geolite2/).
 
 ## Our Setup
-The tutorial's [sample data directory](../sample_data) contains a set of apache web server log files. The Data Collector can read many file formats but for this example we will use compressed logs (.log.gz) that simulates a system that generates log rotated files.
+The tutorial's [sample data directory](../sample_data) contains a set of Apache web server log files. Data Collector can read many file formats, but for this example we will use compressed logs (.log.gz) that simulate a system that generates log rotated files.
 
 The log files contain standard Apache Combined Log Format Data.
 
 ` host rfc931 username date:time request statuscode bytes referrer user_agent `
 
-*If you'd like to generate a larger volume of log files, you can use the [Fake Apache Log Generator](http://github.com/kiritbasu/Fake-Apache-Log-Generator) script*
+*If you'd like to generate a larger volume of log files, you can use the [Fake Apache Log Generator](http://github.com/kiritbasu/Fake-Apache-Log-Generator) script*.
 
-### Setting up an index on ElasticSearch
-We will need to setup an index with the right mapping before we can use [ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html), here's how :
+### Setting up an index on Elasticsearch
+We will need to setup an index with the right mapping before we can use [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html), here's how:
 ```bash
 $ curl -XPUT 'http://localhost:9200/logs' -d '{
     "mappings": {
@@ -42,17 +42,17 @@ $ curl -XPUT 'http://localhost:9200/logs' -d '{
     }
 }
 ```
-This piece of code effectively creates in index called 'logs' and defines a few field types :
+This piece of code effectively creates in index called "logs" and defines a few field types:
 * *timestamp* - this is a date field
 * *geo* - this is a geo_point field that has lat/lon attributes
-* *city* - this is a string type that is not analyzed thus preventing elastic from truncating the data
+* *city* - this is a string type that is not analyzed thus preventing Elasticsearch from truncating the data
 
-*You can use the excellent [Postman API Tool](http://www.getpostman.com/) to interact with Elastic via API*
+*You can use the excellent [Postman API Tool](http://www.getpostman.com/) to interact with Elasticsearch via API*.
 
 ### Installing StreamSets
 * Download and install the latest [StreamSets Data Collector](https://streamsets.com/opensource) binaries.
 
 
-## Lets get started
-* [Part 1 - Basic Log preparation](./log_shipping_to_elasticsearch_part1.md)
-* [Part 2 - Enhancing Log Data & Preparing for production](log_shipping_to_elasticsearch_part2.md)
+## Let's Get Started
+* [Part 1 - Basic Log Preparation](./log_shipping_to_elasticsearch_part1.md)
+* [Part 2 - Enhancing Log Data & Preparing for Production](log_shipping_to_elasticsearch_part2.md)


### PR DESCRIPTION
Fixed camel case for Elasticsearch, replaced Elastic with Elasticsearch (Elastic is the company, Elasticsearch is the software), removed spaces before colons, removed "the" before Data Collector, source => origin, capitalization and periods for consistency. 
Please make sure my changes didn't break links to files/video? 
Left "lat/lon" attributes in case that's the name of the attributes. But if it's not, then it's nicer to say "latitude and longitude attributes" - ?