### PR TITLE
Update the command for creating Elasticsearch index mappings in tutorial-1

### DIFF
--- a/tutorial-1/log_shipping_to_elasticsearch_part2.md
+++ b/tutorial-1/log_shipping_to_elasticsearch_part2.md
@@ -12,7 +12,7 @@ $ curl -XDELETE 'http://localhost:9200/logs'
 * Recreate the Elasticsearch index:
 
 ```bash
-$ curl -X PUT 'http://localhost:9200/logs' -d '{
+$ curl -X PUT -H "Content-Type: application/json" 'http://localhost:9200/logs' -d '{
   "mappings": {
     "logs" : {
       "properties" : {

--- a/tutorial-1/readme.md
+++ b/tutorial-1/readme.md
@@ -28,7 +28,7 @@ The log files contain standard Apache Combined Log Format Data.
 We will need to setup an index with the right mapping before we can use [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html), here's how:
 
 ```bash
-$ curl -X PUT 'http://localhost:9200/logs' -d '{
+$ curl -X PUT -H "Content-Type: application/json" 'http://localhost:9200/logs' -d '{
   "mappings": {
     "logs" : {
       "properties" : {


### PR DESCRIPTION
Elasticsearch 6.0+ REST API now enforces strict content-type checking, so the command now includes the Content-Type header as `application/json`. For more info, see https://stackoverflow.com/questions/47544966/elasticsearch-content-type-header-application-x-www-form-urlencoded-is-not-s